### PR TITLE
agregar creacion temas para rama creacion-sondeos

### DIFF
--- a/app/Http/Controllers/SondeosController.php
+++ b/app/Http/Controllers/SondeosController.php
@@ -3,7 +3,10 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
-use App\Models\Sondeos;
+
+use App\Models\Sondeo;
+use App\Models\Tema;
+
 use Carbon\Carbon; // Facilita el trabajo entre fechas
 
 class SondeosController extends Controller
@@ -13,7 +16,7 @@ class SondeosController extends Controller
      */
     public function index()
     {
-        //
+        return view('index');
     }
 
     /**
@@ -21,7 +24,9 @@ class SondeosController extends Controller
      */
     public function create()
     {
-        return view('sondeos/create');
+        $temas = Tema::orderBy('nombre', 'ASC')->get();
+
+        return view('sondeos/create', ['temas'=>$temas]);
     }
 
     /**
@@ -50,7 +55,7 @@ class SondeosController extends Controller
 
         Sondeo::create($data);
 
-        return redirect()->route('sondeos.index')->with('success', 'Sondeo creado exitosamente.');
+        return redirect()->route('index')->with('success', 'Sondeo creado exitosamente.');
     }
 
     /**

--- a/app/Http/Controllers/TemasController.php
+++ b/app/Http/Controllers/TemasController.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\Tema;
+
+class TemasController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index()
+    {
+        //
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     */
+    public function create()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request)
+    {
+        $request->validate([
+            'nombreTema' => 'required|string|max:40',
+            'descripcionTema' => 'required|string|max:500',
+        ]);
+
+        $tema = Tema::create([
+            'nombre' => $request->input('nombreTema'),
+            'descripcion' => $request->input('descripcionTema'),
+        ]);
+        
+        return redirect()->back();
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(string $id)
+    {
+        //
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     */
+    public function edit(string $id)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, string $id)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(string $id)
+    {
+        //
+    }
+}

--- a/app/Models/Sondeo.php
+++ b/app/Models/Sondeo.php
@@ -7,8 +7,6 @@ use Illuminate\Database\Eloquent\Model;
 class Sondeo extends Model
 {
     protected $fillable=[
-        'idSondeo',
-        'idAdministrador',
         'idTema',
         'idCriterio',
         'titulo',

--- a/app/Models/Tema.php
+++ b/app/Models/Tema.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Tema extends Model
+{
+    use HasFactory;
+    
+    protected $fillable = [
+        'nombre',
+        'descripcion'
+    ];
+
+    protected $primaryKey='idTema';
+}

--- a/public/css/sondeo-create.css
+++ b/public/css/sondeo-create.css
@@ -1,5 +1,0 @@
-/* Estilo para el botón activo */
-.btn-active.btn-outline-secondary.rounded-3.rounded-bottom-0 {
-    background-color: #555c63;
-    color: #fff;
-}

--- a/public/css/sondeos-create.css
+++ b/public/css/sondeos-create.css
@@ -1,0 +1,5 @@
+/* Estilo para el botón activo */
+.btn-active.btn-outline-secondary.rounded-3.rounded-bottom-0 {
+    background-color: #555c63;
+    color: #fff;
+}

--- a/public/js/sondeos-create.js
+++ b/public/js/sondeos-create.js
@@ -1,0 +1,22 @@
+$(document).ready(function () {
+        // Función para mostrar el div correspondiente y resaltar el botón activo
+        function showDiv(divId, buttonId) {
+        $('#configuracionDiv, #preguntasDiv, #parametrizacionDiv').hide();
+        $('#' + divId).show();
+        $('.btn').removeClass('btn-active');
+        $('#' + buttonId).addClass('btn-active');
+        }
+    
+        // Agregar eventos para cada botón
+        $('#btnConfiguracion').click(function () {
+        showDiv('configuracionDiv', 'btnConfiguracion');
+        });
+    
+        $('#btnPreguntas').click(function () {
+        showDiv('preguntasDiv', 'btnPreguntas');
+        });
+    
+        $('#btnParametrizacion').click(function () {
+        showDiv('parametrizacionDiv', 'btnParametrizacion');
+        });
+});

--- a/resources/views/indexAdmin.blade.php
+++ b/resources/views/indexAdmin.blade.php
@@ -16,5 +16,7 @@
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.10.2/dist/umd/popper.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.min.js"></script>
+
+    @yield('scripts')
 </body>
 </html>

--- a/resources/views/indexAdmin.blade.php
+++ b/resources/views/indexAdmin.blade.php
@@ -12,5 +12,9 @@
     @include('partials/navAdmin')
 
     @yield('contenido')
+
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.10.2/dist/umd/popper.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.min.js"></script>
 </body>
 </html>

--- a/resources/views/partials/navAdmin.blade.php
+++ b/resources/views/partials/navAdmin.blade.php
@@ -1,10 +1,10 @@
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
     <div class="container-fluid">
-        <a class="navbar-brand" href="">SSF</a>
+        <a class="navbar-brand" href="{{route('index')}}">SSF</a>
         <div class="collapse navbar-collapse" id="navbarText">
             <ul class="navbar-nav mx-auto gap-3">
                 <li class="nav-item">
-                    <a class="nav-link" href="">Inicio</a>
+                    <a class="nav-link" href="{{route('index')}}">Inicio</a>
                 </li>
                 <li class="nav-item">
                     <a class="nav-link" href="{{route('sondeos.create')}}">Crear Sondeo</a>

--- a/resources/views/sondeos/create.blade.php
+++ b/resources/views/sondeos/create.blade.php
@@ -136,7 +136,9 @@
                             <label for="descripcionTema" class="form-label">Descripción del Tema:</label>
                             <textarea class="form-control" id="descripcionTema" name="descripcionTema" rows="3" required></textarea>
                         </div>
-                        <button type="submit" class="btn btn-primary">Guardar Tema</button>
+                        <div class="d-flex justify-content-center">
+                            <button type="submit" class="btn btn-primary">Guardar Tema</button>
+                        </div>
                     </form>
                 </div>
             </div>

--- a/resources/views/sondeos/create.blade.php
+++ b/resources/views/sondeos/create.blade.php
@@ -3,7 +3,7 @@
 @section('title', 'Crear Sondeo')
 
 @section('styles')
-    <link rel="stylesheet" href="{{ asset('css/sondeo-create.css') }}">
+    <link rel="stylesheet" href="{{ asset('css/sondeos-create.css') }}">
 @endsection
 
 @section('contenido')
@@ -21,8 +21,8 @@
                 @csrf
                 <!-- Contenido del formulario oculto por defecto -->
                 <div id="formularioDiv">
+                    <!-- Contenido de Configuración -->
                     <div class="container mt-3" id="configuracionDiv">
-                        <!-- Contenido de Configuración -->
                         <div class="row mb-4">
                             <div class="col">
                                 <div>
@@ -64,23 +64,20 @@
                         </div>
                     </div>
     
+                    <!-- Contenido de Preguntas -->
                     <div class="container mt-5" id="preguntasDiv" style="display: none;">
-                        <!-- Contenido de Preguntas -->
-                        <div class="row mb-4">
+                        <div id="preguntasContainer">
+                            <!-- Aquí mostraremos las preguntas existentes y las nuevas que se agreguen -->
+                        </div>
+                        <div class="row mt-3">
                             <div class="col">
-                                <label for="pregunta1">Pregunta 1</label>
-                                <input type="text" name="pregunta1" id="pregunta1" class="form-control">
-                            </div>
-                            <div class="col">
-                                <label for="pregunta2">Pregunta 2</label>
-                                <input type="text" name="pregunta2" id="pregunta2" class="form-control">
+                                <button type="button" class="btn btn-primary" onclick="agregarPregunta()">Agregar Pregunta</button>
                             </div>
                         </div>
-                        <!-- Agregar más preguntas si es necesario -->
                     </div>
     
+                    <!-- Contenido de Parametrización -->
                     <div class="container mt-5" id="parametrizacionDiv" style="display: none;">
-                        <!-- Contenido de Parametrización -->
                         <div class="row mb-4">
                             <div class="col">
                                 <label for="parametro1">Parámetro 1</label>
@@ -93,7 +90,7 @@
                             <!-- Agregar más parámetros si es necesario -->
                         </div>
 
-                        <!-- Botón para enviar el formulario -->
+                        <!-- Botón para guardar el formulario -->
                         <div class="row mt-4 mb-3 text-center">
                             <div class="col">
                                 <button type="submit" class="btn btn-primary">Guardar Sondeo</button>
@@ -104,17 +101,6 @@
             </form>
         </div>
     </div>
-
-    <script>
-        // Función para mostrar el div correspondiente y resaltar el botón activo
-        function showDiv(divId, buttonId) {
-            $('#configuracionDiv, #preguntasDiv, #parametrizacionDiv').hide();
-            $('#' + divId).show();
-            $('.btn').removeClass('btn-active');
-            $('#' + buttonId).addClass('btn-active');
-        }
-    </script>
-
 
     <!-- Modal para crear un nuevo tema -->
     <div class="modal fade" id="crearTemaModal" tabindex="-1" aria-labelledby="crearTemaModalLabel" aria-hidden="true">
@@ -143,4 +129,8 @@
             </div>
         </div>
     </div>
+@endsection
+
+@section('scripts')
+    <script src="{{ asset('js/sondeos-create.js') }}"></script>
 @endsection

--- a/resources/views/sondeos/create.blade.php
+++ b/resources/views/sondeos/create.blade.php
@@ -17,7 +17,7 @@
         </div>
 
         <div class="bg-white mb-4 border rounded-bottom-3 border-secondary-subtle">
-            <form class="p-3" action="{{route('sondeos.store')}}" method="POST">
+            <form class="p-3" action="{{ route('sondeos.store') }}" method="POST">
                 @csrf
                 <!-- Contenido del formulario oculto por defecto -->
                 <div id="formularioDiv">
@@ -25,13 +25,18 @@
                         <!-- Contenido de Configuración -->
                         <div class="row mb-4">
                             <div class="col">
-                                <label for="tema">Tema</label>
-                                <select name="idTema" id="">
-                                    @foreach($temas as $tema)
-                                        <option value="{{$tema->idTema}}">{{$tema->nombre}}</option>
-                                    @endforeach
-                                </select>
-                            </div>
+                                <div>
+                                    <label for="tema">Tema</label>
+                                </div>
+                                <div class="input-group">
+                                    <select name="idTema" id="idTema" class="form-select">
+                                        @foreach($temas as $tema)
+                                            <option value="{{$tema->idTema}}">{{$tema->nombre}}</option>                                       
+                                        @endforeach
+                                    </select>
+                                    <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#crearTemaModal">Nuevo</button>
+                                </div>
+                            </div>                            
                             <div class="col">
                                 <label for="titulo">Título Sondeo</label>
                                 <input type="text" name="titulo" id="titulo" class="form-control">
@@ -110,4 +115,31 @@
             $('#' + buttonId).addClass('btn-active');
         }
     </script>
+
+
+    <!-- Modal para crear un nuevo tema -->
+    <div class="modal fade" id="crearTemaModal" tabindex="-1" aria-labelledby="crearTemaModalLabel" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="crearTemaModalLabel">Nuevo Tema</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <form id="crearTemaForm" action="{{ route('temas.store') }}" method="POST">
+                        @csrf
+                        <div class="mb-3">
+                            <label for="nombreTema" class="form-label">Nombre del Tema:</label>
+                            <input type="text" class="form-control" id="nombreTema" name="nombreTema" required>
+                        </div>
+                        <div class="mb-3">
+                            <label for="descripcionTema" class="form-label">Descripción del Tema:</label>
+                            <textarea class="form-control" id="descripcionTema" name="descripcionTema" rows="3" required></textarea>
+                        </div>
+                        <button type="submit" class="btn btn-primary">Guardar Tema</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
 @endsection

--- a/resources/views/sondeos/create.blade.php
+++ b/resources/views/sondeos/create.blade.php
@@ -26,7 +26,11 @@
                         <div class="row mb-4">
                             <div class="col">
                                 <label for="tema">Tema</label>
-                                <input type="search" name="tema" id="tema" class="form-control">
+                                <select name="idTema" id="">
+                                    @foreach($temas as $tema)
+                                        <option value="{{$tema->idTema}}">{{$tema->nombre}}</option>
+                                    @endforeach
+                                </select>
                             </div>
                             <div class="col">
                                 <label for="titulo">Título Sondeo</label>

--- a/resources/views/sondeos/create.blade.php
+++ b/resources/views/sondeos/create.blade.php
@@ -105,7 +105,6 @@
         </div>
     </div>
 
-    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     <script>
         // Función para mostrar el div correspondiente y resaltar el botón activo
         function showDiv(divId, buttonId) {

--- a/routes/web.php
+++ b/routes/web.php
@@ -33,3 +33,6 @@ Route::get('sondeos/create', 'SondeosController@create')->name('sondeos.create')
 Route::post('sondeos/store', 'SondeosController@store')->name('sondeos.store');
 
 
+// RUTAS TEMAS
+Route::post('temas/store', 'TemasController@store')->name('temas.store');
+

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,10 +17,14 @@ use Illuminate\Support\Facades\Route;
 */
 
 Route::get('/', function () {
-    $sondeos = Sondeo::all();
-        
-    return view('index', ['sondeos'=>$sondeos]);
+    return view('indexAdmin');
+
+    // $sondeos = Sondeo::all();
+    
+    // return view('index', ['sondeos'=>$sondeos]);
 });
+
+Route::get('index', 'SondeosController@index')->name('index');
 
 
 // RUTAS SONDEOS
@@ -29,5 +33,3 @@ Route::get('sondeos/create', 'SondeosController@create')->name('sondeos.create')
 Route::post('sondeos/store', 'SondeosController@store')->name('sondeos.store');
 
 
-
-Route::get('index', 'SondeosController@index')->name('index');


### PR DESCRIPTION
avances en la creacion de sondeos, se ha codificado lo necesario para la creacion de temas a partir de un boton desde la vista sondeos.create (controlador, modelo, ruta y un modal en vez de vista para temas).

se reorganiza indexAdmin, agregando un yield para dejar la conexion a scripts, asi crear el archivo js necesario para la funcionalidad de sondeos.create.